### PR TITLE
removing pipefail

### DIFF
--- a/support/get-resources.sh
+++ b/support/get-resources.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-#set -euo pipefail
 
 tmpdir=$(mktemp -d -p .)
 svr=$(oc whoami --show-server | sed -e "s/[^/]*\/\/\([^@]*@\)\?\([^:/]*\).*/\2/")


### PR DESCRIPTION
This will prevent issues similar to the problem we had with the staging cluster which had somehow ended up with its metrics api version getting deleted.  We still want as much data as possible to be pulled from any queries that ran fine.  The failure will still be visible to the person running the script.