### PR TITLE
exclude addresses from enmasses cr query

### DIFF
--- a/support/get-resources.sh
+++ b/support/get-resources.sh
@@ -73,7 +73,7 @@ cat << EOF > ${work_file}
     },
     {
       "id": "enmasse-crs",
-      "cmd": "(oc get $(echo $(oc api-resources | grep enmasse | awk '{print $1}' | grep -v addressspaceschema) | sed 's/ /,/g') --all-namespaces  -o json; oc get addressspaceschemas -o json) | jq 'reduce inputs as \$i (.; .items += \$i.items)'",
+      "cmd": "(oc get $(echo $(oc api-resources | grep enmasse | awk '{print $1}' | egrep -v '^(addressspaceschemas|addresses)$') | sed 's/ /,/g') --all-namespaces  -o json; oc get addressspaceschemas -o json) | jq 'reduce inputs as \$i (.; .items += \$i.items)'",
       "type": "json"
     },
     {


### PR DESCRIPTION
Clusters where AMQ is heavily used can have a large number of addresses which can adversely affect cluster performance, cause timeouts, cause the snapshot dump to take much longer, etc.  Ultimately, the addresses are virtual resources derived from other the CRs which are still being extracted.