### PR TITLE
feat: ocm - get cluster logs from hive

### DIFF
--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -28,6 +28,10 @@ ocm/get/current_account:
 ocm/cluster/list:
 	@${OCM} cluster list
 
+.PHONY: ocm/cluster/logs
+ocm/cluster/logs:
+	@${OCM_SH} get_cluster_logs
+
 .PHONY: ocm/cluster/create
 ocm/cluster/create:
 	@${OCM_SH} create_cluster

--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -13,6 +13,7 @@ readonly CLUSTER_KUBECONFIG_FILE="${OCM_DIR}/cluster.kubeconfig"
 readonly CLUSTER_CONFIGURATION_FILE="${OCM_DIR}/cluster.json"
 readonly CLUSTER_DETAILS_FILE="${OCM_DIR}/cluster-details.json"
 readonly CLUSTER_CREDENTIALS_FILE="${OCM_DIR}/cluster-credentials.json"
+readonly CLUSTER_LOGS_FILE="${OCM_DIR}/cluster.log"
 
 readonly RHMI_OPERATOR_NAMESPACE="redhat-rhmi-operator"
 
@@ -181,6 +182,10 @@ upgrade_cluster() {
     wait_for "ocm get cluster ${cluster_id} | jq -r .openshift_version | grep -q ${UPGRADE_VERSION}" "OpenShift upgrade" "90m" "300"
 }
 
+get_cluster_logs() {
+    ocm get "/api/clusters_mgmt/v1/clusters/$(get_cluster_id)/logs/hive" | jq -r .content | tee "${CLUSTER_LOGS_FILE}"
+}
+
 get_cluster_id() {
     jq -r .id < "${CLUSTER_DETAILS_FILE}"
 }
@@ -307,6 +312,8 @@ delete_cluster                    - delete RHMI product & OSD cluster
 Optional exported variables:
 - SENDGRID_API_KEY                  a token for creating SMTP secret
 ==========================================================================================
+get_cluster_logs                  - get logs from hive and save them to ${CLUSTER_LOGS_FILE}
+==========================================================================================
 " "${0}"
 }
 
@@ -339,6 +346,10 @@ main() {
             ;;
         upgrade_cluster)
             upgrade_cluster
+            exit 0
+            ;;
+        get_cluster_logs)
+            get_cluster_logs
             exit 0
             ;;
         -h | --help)


### PR DESCRIPTION
### Motivation

2.x nightly pipelines sometimes fail on cluster provision (due to timeout). It would be useful to have the logs from hive to see what's going on.

This will be also reflected in ci-cd repo.

### Verification
Get some cluster's id from ocm, save it to `ocm/cluster-details.json` and run the new make target.
```
mkdir -p ocm && echo '{"id": "<your_cluster_id>"}' > ocm/cluster-details.json
make ocm/cluster/logs
```
It should print out logs to the console and save them to `ocm/cluster.log`