### PR TITLE
feat: use self-signed certs by default, patch alerting email address

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -125,7 +125,7 @@ install_rhmi() {
     rhmi_name=$(get_rhmi_name)
 
     oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" patch rhmi "${rhmi_name}" -n ${RHMI_OPERATOR_NAMESPACE} \
-        --type "json" -p "[{\"op\": \"replace\", \"path\": \"/spec/useClusterStorage\", \"value\": \"${USE_CLUSTER_STORAGE:-true}\"}]"
+        --type=merge -p "{\"spec\":{\"useClusterStorage\": \"${USE_CLUSTER_STORAGE:-true}\", \"selfSignedCerts\": ${SELF_SIGNED_CERTS:-true} }}"
 
     # Create a valid SMTP secret if SENDGRID_API_KEY variable is exported
     if [[ -n "${SENDGRID_API_KEY:-}" ]]; then
@@ -302,6 +302,7 @@ install_rhmi                      - install RHMI using addon-type installation
 Optional exported variables:
 - USE_CLUSTER_STORAGE               true/false - use OpenShift/AWS storage (default: true)
 - SENDGRID_API_KEY                  a token for creating SMTP secret
+- SELF_SIGNED_CERTS                 true/false - cluster certificate can be invalid
 ==========================================================================================
 upgrade_cluster                   - upgrade OSD cluster
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation
* when using addon-flow-type installation, there's a fixed alerting email address set in CSV and that needs to be changed to stop bugging the default mailing list (for nightly pipelines)
* due to an issue with certs in stage environment it's reasonable to use `selfSignedCerts: true` by default to avoid unnecessary failures during installation

### Comments
[This patch](https://github.com/integr8ly/rhmi-utils/pull/27/files#diff-e9453c26249c5306c79a77e19f23e49cR135) is far from being ideal (if the order of env vars in deployment changes or new variable is added in a future, it will patch a wrong env var). I'm trying to get some help with this.