### PR TITLE
fix: add missing sop steps

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -9,6 +9,11 @@ readonly REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 readonly OCM_DIR="${REPO_DIR}/ocm"
 
 readonly AWS_CREDENTIALS_FILE="${OCM_DIR}/aws.json"
+readonly TEMPLATES_DIR="${REPO_DIR}/templates/ocm"
+readonly CLUSTER_TEMPLATE_FILE="${TEMPLATES_DIR}/cluster-template.json"
+readonly CR_AWS_STRATEGIES_CONFIGMAP_FILE="${TEMPLATES_DIR}/cr-aws-strategies.yml"
+readonly LB_CLUSTER_QUOTA_FILE="${TEMPLATES_DIR}/load-balancer-cluster-quota.json"
+readonly CLUSTER_STORAGE_QUOTA_FILE="${TEMPLATES_DIR}/cluster-storage-quota.json"
 readonly CLUSTER_KUBECONFIG_FILE="${OCM_DIR}/cluster.kubeconfig"
 readonly CLUSTER_CONFIGURATION_FILE="${OCM_DIR}/cluster.json"
 readonly CLUSTER_DETAILS_FILE="${OCM_DIR}/cluster-details.json"
@@ -79,7 +84,7 @@ create_cluster_configuration_file() {
     timestamp=$(get_expiration_timestamp "${OCM_CLUSTER_LIFESPAN}")
 
     jq ".expiration_timestamp = \"${timestamp}\" | .name = \"${OCM_CLUSTER_NAME}\" | .region.id = \"${OCM_CLUSTER_REGION}\"" \
-        < "${REPO_DIR}/templates/ocm/cluster-template.json" \
+        < "${CLUSTER_TEMPLATE_FILE}" \
         > "${CLUSTER_CONFIGURATION_FILE}"
 	
     if [ "${BYOC}" = true ]; then
@@ -116,6 +121,7 @@ install_rhmi() {
     local infra_id
     local csv_name
 
+    : "${USE_CLUSTER_STORAGE:=true}"
     cluster_id=$(get_cluster_id)
 
     echo '{"addon":{"id":"rhmi"}}' | ocm post "/api/clusters_mgmt/v1/clusters/${cluster_id}/addons"
@@ -124,8 +130,13 @@ install_rhmi() {
 
     rhmi_name=$(get_rhmi_name)
 
+    if [[ "${USE_CLUSTER_STORAGE}" == false ]]; then
+        oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" create -f \
+        "${CR_AWS_STRATEGIES_CONFIGMAP_FILE},${LB_CLUSTER_QUOTA_FILE},${CLUSTER_STORAGE_QUOTA_FILE}"
+    fi
+
     oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" patch rhmi "${rhmi_name}" -n ${RHMI_OPERATOR_NAMESPACE} \
-        --type=merge -p "{\"spec\":{\"useClusterStorage\": \"${USE_CLUSTER_STORAGE:-true}\", \"selfSignedCerts\": ${SELF_SIGNED_CERTS:-true} }}"
+        --type=merge -p "{\"spec\":{\"useClusterStorage\": \"${USE_CLUSTER_STORAGE}\", \"selfSignedCerts\": ${SELF_SIGNED_CERTS:-true} }}"
 
     # Change alerting email address is ALERTING_EMAIL_ADDRESS variable is set
     if [[ -n "${ALERTING_EMAIL_ADDRESS:-}" ]]; then

--- a/templates/ocm/cluster-storage-quota.json
+++ b/templates/ocm/cluster-storage-quota.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "quota.openshift.io/v1",
+    "kind": "ClusterResourceQuota",
+    "metadata": {
+        "name": "rhmi-persistent-volume-quota"
+    },
+    "spec": {
+        "quota": {
+            "hard": {
+                "requests.storage": "100Gi"
+            }
+        },
+        "selector": {
+            "annotations": null,
+            "labels": {
+                "matchExpressions": [
+                    {
+                        "key": "managed.openshift.io/storage-pv-quota-exempt",
+                        "operator": "DoesNotExist"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/templates/ocm/cr-aws-strategies.yml
+++ b/templates/ocm/cr-aws-strategies.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-resources-aws-strategies
+  namespace: redhat-rhmi-operator
+data:
+  blobstorage: |
+    {"production": { "createStrategy": {}, "deleteStrategy": {} }}
+  postgres: |
+    {"production": { "createStrategy": {"PreferredMaintenanceWindow":"sun:23:00-mon:01:30","PreferredBackupWindow":"02:00-02:30"}, "deleteStrategy": {} }}
+  redis: |
+    {"production": { "createStrategy": {"PreferredMaintenanceWindow":"sun:23:00-mon:01:30","SnapshotWindow":"02:00-03:00"}, "deleteStrategy": {} }}

--- a/templates/ocm/load-balancer-cluster-quota.json
+++ b/templates/ocm/load-balancer-cluster-quota.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "quota.openshift.io/v1",
+    "kind": "ClusterResourceQuota",
+    "metadata": {
+        "name": "rhmi-loadbalancer-quota"
+    },
+    "spec": {
+        "quota": {
+            "hard": {
+                "services.loadbalancers": "0"
+            }
+        },
+        "selector": {
+            "annotations": null,
+            "labels": {
+                "matchExpressions": [
+                    {
+                        "key": "managed.openshift.io/service-lb-quota-exempt",
+                        "operator": "DoesNotExist"
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
Thanks to these changes, our pipelines will be able to perform the installation exactly as per SOP.

1. Create a cluster quotas:
https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/provision_rhmi_cluster.md#add-the-cluster-quotas

2. Add aws maintenance and backup windows:
https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/create_cluster_aws_maintenance_and_backup_windows.md

I added a condition to create these quotas and backup windows only in case of using the AWS storage.

I also verified it locally
```
➜  rhmi-utils git:(master) ✗ make ocm/install/rhmi-addon USE_CLUSTER_STORAGE=true
➜  rhmi-utils git:(master) ✗ make ocm/install/rhmi-addon USE_CLUSTER_STORAGE=false
...
configmap/cloud-resources-aws-strategies created
clusterresourcequota.quota.openshift.io/rhmi-loadbalancer-quota created
clusterresourcequota.quota.openshift.io/rhmi-persistent-volume-quota created
```