### PR TITLE
improvements to usability and to amq resource extraction

### DIFF
--- a/support/get-resources.sh
+++ b/support/get-resources.sh
@@ -81,7 +81,7 @@ cat << EOF > ${work_file}
     },
     {
       "id": "enmasse-crs",
-      "cmd": "oc get $(echo $(oc api-resources | grep enmasse | awk '{print $1}') | sed 's/ /,/g') --all-namespaces -o json | jq 'reduce inputs as \$i (.; .items += \$i.items)'",
+      "cmd": "(oc get $(echo $(oc api-resources | grep enmasse | awk '{print $1}' | egrep -v '^addressspaceschemas$') | sed 's/ /,/g') --all-namespaces  -o json; oc get addressspaceschemas -o json) | jq 'reduce inputs as \$i (.; .items += \$i.items)'",
       "type": "json"
     },
     {


### PR DESCRIPTION
[INTLY-8432](https://issues.redhat.com/browse/INTLY-8432)
- simplified amq info extract query cmd, compatible with rhmi 1.x and rhmi 2.x
- no longer exclude enmasse Addresses
- Fixes usability issue introduced when OS-X compatibility was added whereby output file was left in /tmp/tmp/... folder instead of being written to current directory
