### PR TITLE
INTLY-6400 - Fix generated resource gz emtpy if rhmi is not installed

### DIFF
--- a/support/get-resources.sh
+++ b/support/get-resources.sh
@@ -104,7 +104,11 @@ for i in ${tmpdir}/*.raw; do
 done
 
 for i in ${tmpdir}/*.json; do
-  cat ${work_file} | jq --arg id $(basename $i .json) --slurpfile x $i '[.[] | select(.id==$id).result=$x[]]' > $work_file.tmp && cp $work_file.tmp ${work_file} && rm $work_file.tmp
+  if [ -s "$i" ]; then
+    cat ${work_file} | jq --arg id $(basename $i .json) --slurpfile x $i '[.[] | select(.id==$id).result=$x[]]' > $work_file.tmp && cp $work_file.tmp ${work_file} && rm $work_file.tmp
+  else
+    echo "Ignoring empty $i file"
+  fi
 done
 
 gzip ${work_file} --suffix=.gz -c > ${output_file} && rm ${work_file}


### PR DESCRIPTION
## Description
When RHMI is **not** installed and `./support/get-resources.sh` is ran, the outputted `enmasse-cr.json` is empty due to the `addressspaceschemas` resource type is not present and errors out.

When combining the generated jsons to the gz file, this will result in a file with just an empty array.

To fix this, the json files are now checked on whether they are empty. This would allow the script to run with or without RHMI is installed on the cluster

Jira:
* https://issues.redhat.com/browse/INTLY-6400